### PR TITLE
Fix UNIT_SYSTEM not set necessarily since 0.94

### DIFF
--- a/custom_components/wundergroundpws/sensor.py
+++ b/custom_components/wundergroundpws/sensor.py
@@ -44,7 +44,10 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 conf_file = config.get_default_config_dir() + '/configuration.yaml'
 load_config = config.load_yaml_config_file(conf_file)
 
-UNIT_SYSTEM = load_config['homeassistant']['unit_system']
+try:
+    UNIT_SYSTEM = load_config['homeassistant']['unit_system']
+except KeyError as err:
+    UNIT_SYSTEM = "metric"
 
 if UNIT_SYSTEM == 'imperial':
     TEMPUNIT = TEMP_FAHRENHEIT


### PR DESCRIPTION
Since ~ 0.94 some basic attributes of the Homeassistant installation can be set via GUI. Until that is applied, a unit_system does not seem to be set causing home assistant as whole to crash.