### PR TITLE
Update sensor.py to display extra precision

### DIFF
--- a/custom_components/wundergroundpws/sensor.py
+++ b/custom_components/wundergroundpws/sensor.py
@@ -27,7 +27,7 @@ from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 import homeassistant.config as config
 
-_RESOURCECURRENT = 'https://api.weather.com/v2/pws/observations/current?stationId={}&format=json&units={}&apiKey={}'
+_RESOURCECURRENT = 'https://api.weather.com/v2/pws/observations/current?stationId={}&numericPrecision=decimal&format=json&units={}&apiKey={}'
 _RESOURCEFORECAST = 'https://api.weather.com/v3/wx/forecast/daily/5day?geocode={},{}&units={}&{}&format=json&apiKey={}'
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
I was troubled that my temp was an interger, unlike all my other temps which showed as xx.x

The API (https://docs.google.com/document/d/1KGb8bTVYRsNgljnNH67AMhckY8AQT2FVwZ9urj8SWBs/edit) will return only integers unless the parameter numericPrecision=decimal is part of the request.