### PR TITLE
Drop loop= kwarg from async_timeout.timeout

### DIFF
--- a/custom_components/wundergroundpws/sensor.py
+++ b/custom_components/wundergroundpws/sensor.py
@@ -535,7 +535,7 @@ class WUndergroundData:
         """Get the latest data from WUnderground."""
         headers = {'Accept-Encoding': 'gzip'}
         try:
-            with async_timeout.timeout(10, loop=self._hass.loop):
+            with async_timeout.timeout(10):
                 response = await self._session.get(self._build_url(_RESOURCECURRENT), headers=headers)
             result_current = await response.json()
 
@@ -546,7 +546,7 @@ class WUndergroundData:
 
             if result_current is None:
                 raise ValueError('NO CURRENT RESULT')
-            with async_timeout.timeout(10, loop=self._hass.loop):
+            with async_timeout.timeout(10):
                 response = await self._session.get(self._build_url(_RESOURCEFORECAST), headers=headers)
             result_forecast = await response.json()
 


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed

Fixes

`
2021-11-04 15:17:46 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_timeout.timeout with loop keyword argument. The loop keyword argument is deprecated and calls will fail after Home Assistant 2022.2. Please report issue to the custom component author for wundergroundpws using this method at custom_components/wundergroundpws/sensor.py, line 545: with async_timeout.timeout(10, loop=self._hass.loop):
`
`
2021-11-04 15:17:47 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_timeout.timeout with loop keyword argument. The loop keyword argument is deprecated and calls will fail after Home Assistant 2022.2. Please report issue to the custom component author for wundergroundpws using this method at custom_components/wundergroundpws/sensor.py, line 556: with async_timeout.timeout(10, loop=self._hass.loop):
`