### PR TITLE
New condition 'Iso T-Storms'

### DIFF
--- a/custom_components/wundergroundpws/wunderground_data.py
+++ b/custom_components/wundergroundpws/wunderground_data.py
@@ -68,6 +68,7 @@ class WUndergroundData:
         ],
         'lightning': [
             'T-Storms',
+            'Iso T-Storms',
         ],
         'lightning-rainy': [
             "Rain/Thunder",


### PR DESCRIPTION
This error originated from a custom integration.

Logger: custom_components.wundergroundpws.wunderground_data
Source: custom_components/wundergroundpws/wunderground_data.py:212
Integration: Wundergroundpws (documentation, issues)
First occurred: 10:01:15 (278 occurrences)
Last logged: 11:10:15

Unsupported condition string "Iso T-Storms". Please update WUndergroundData.condition_map and/or WUndergroundData.condition_modifiers.