### PR TITLE
Updates to enable integration of Wundergroundpws Integration to install via HACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,21 @@ Please consider this when using the following information.
 
 # Installation
 
-Download the latest v2.X.X release zip file from this repository.
-Extract the zip file to a temporary directory.
--------
-Copy the custom_components directory from the extracted file into your .homeassistant directory.  
+## Install using HACS
+
+1. The installation is done inside [HACS](https://hacs.xyz/) (Home Assistant Community Store). If you don't have HACS, you must install it before adding this integration. [Installation instructions here.](https://hacs.xyz/docs/setup/download)
+2. Once HACS is installed, navigate to the 'Integrations' tab in HACS and search for the 'Wundergroundpws' integration there. Click "Download this repository in HACS". On the next screen, select "Download". Once fully downloaded, restart Home Assistant.
+
+
+## Manual Install
+
+1. Download the latest [v2.X.X release](https://github.com/cytech/Home-Assistant-wundergroundpws/releases) zip file from the repository and extract the zip file to a temporary directory.
+2. Copy the custom_components directory from the extracted file into your .homeassistant directory.  
 or  
 Copy the contents of the custom_components directory from the extracted file into an existing custom_components directory in your .homeassistant directory.
+3. Resstart Home Assistant
+
+## Create Instance
 
 1. In Home Assistant Settings, select DEVICES & SERVICES, then ADD INTEGRATION.  
 2. Select the "wundergroundpws" integration.  

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Weather Underground PWS",
+  "render_readme": "true",
+  "iot_class": "Cloud Polling",
+  "homeassistant": "2023.9.0"
+}


### PR DESCRIPTION
Provides updates via this PR to address the installation of this HA Integration via HACS. 

This change consists of the addition of `hacs.json` and updates to the `README.md` documentation file. 

I have tested these updates in my local HA instance via [my forked repository](https://github.com/dalethestirling/Home-Assistant-wundergroundpws) with the following versions:
HASSIO: `Home Assistant OS 14.2`
Home Assistant: `2025.2.5`
HACS: `2.0.5`

This was not done using the releases in the root repository but using commit [d6f33d1
Preview](https://github.com/cytech/Home-Assistant-wundergroundpws/commit/d6f33d16ef5d0956edcea31b023fad6131556c90), that is proposed to be merged via thsi PR.