### PR TITLE
Fix/none type error

### DIFF
--- a/custom_components/wundergroundpws/coordinator.py
+++ b/custom_components/wundergroundpws/coordinator.py
@@ -193,6 +193,9 @@ class WundergroundPWSUpdateCoordinator(DataUpdateCoordinator):
         self._features.add(feature)
 
     def get_condition(self, field):
+        if not self.data:
+            return None
+
         if field in [
             FIELD_CONDITION_HUMIDITY,
             FIELD_CONDITION_WINDDIR,
@@ -202,6 +205,9 @@ class WundergroundPWSUpdateCoordinator(DataUpdateCoordinator):
         return self.data[FIELD_OBSERVATIONS][0][self.unit_system][field]
 
     def get_forecast(self, field, period=0):
+        if not self.data:
+            return None
+
         try:
             if field in [
                 FIELD_FORECAST_TEMPERATUREMAX,
@@ -212,8 +218,12 @@ class WundergroundPWSUpdateCoordinator(DataUpdateCoordinator):
             ]:
                 # Those fields exist per-day, rather than per dayPart, so the period is halved
                 return self.data[field][int(period / 2)]
+
+            if FIELD_DAYPART not in self.data:
+                return None
+
             return self.data[FIELD_DAYPART][0][field][period]
-        except IndexError:
+        except (KeyError, TypeError, IndexError):
             return None
 
     @classmethod

--- a/custom_components/wundergroundpws/sensor.py
+++ b/custom_components/wundergroundpws/sensor.py
@@ -174,16 +174,26 @@ def _get_sensor_data(
         forecast_day: int | None = None
 ) -> Any:
     """Get sensor data."""
-    if feature == FEATURE_CONDITIONS:
-        return sensors[FIELD_OBSERVATIONS][0][unit_system][kind]
-    elif feature == FEATURE_FORECAST:
-        return sensors[kind][forecast_day]
-    elif feature == FEATURE_FORECAST_DAYPART:
-        return sensors[FIELD_DAYPART][0][kind][forecast_day]
-    elif feature == FEATURE_OBSERVATIONS:
-        return sensors[FIELD_OBSERVATIONS][0][kind]
-    else:
-        return sensors
+    # NEU: Null-Check am Anfang
+    if sensors is None:
+        _LOGGER.debug("Sensor data is None, returning None")
+        return None
+
+    try:
+        if feature == FEATURE_CONDITIONS:
+            return sensors[FIELD_OBSERVATIONS][0][unit_system][kind]
+        elif feature == FEATURE_FORECAST:
+            return sensors[kind][forecast_day]
+        elif feature == FEATURE_FORECAST_DAYPART:
+            return sensors[FIELD_DAYPART][0][kind][forecast_day]
+        elif feature == FEATURE_OBSERVATIONS:
+            return sensors[FIELD_OBSERVATIONS][0][kind]
+        else:
+            return sensors
+    except (KeyError, TypeError, IndexError) as e:
+        # NEU: Exception-Handling
+        _LOGGER.debug(f"Error getting sensor data for {kind} (feature={feature}): {e}")
+        return None
 
 
 class WundergroundPWSForecastSensor(WundergroundPWSSensor):

--- a/custom_components/wundergroundpws/sensor.py
+++ b/custom_components/wundergroundpws/sensor.py
@@ -133,6 +133,8 @@ class WundergroundPWSSensor(CoordinatorEntity, SensorEntity):
         if self.entity_description.key in self.coordinator._tranfile.keys() or \
                 self.entity_description.key in self.coordinator._tranfile[FIELD_DAYPART].keys():
             if self.forecast_day is not None:
+                if self.coordinator.data is None:
+                    return self.entity_description.name
                 if self.entity_description.feature == FEATURE_FORECAST_DAYPART:
                     if self.coordinator.data[FIELD_DAYPART][0][FIELD_FORECAST_DAYPARTNAME][self.forecast_day] is not None:
                         return self.coordinator._tranfile[FIELD_DAYPART][self.entity_description.key] + " " + \


### PR DESCRIPTION
Prevent 'NoneType is not subscriptable' crashes by checking if sensors is None and wrapping data access in try/except block. Sensors now show 'unavailable' status instead of crashing when API data is missing.

extends https://github.com/cytech/Home-Assistant-wundergroundpws/pull/305 by fixing `sensor.py`

Problem accurs, when there are no data available for specific stationID