### PR TITLE
Fix exception handling in coordinator.py for Python 3

### DIFF
--- a/custom_components/wundergroundpws/coordinator.py
+++ b/custom_components/wundergroundpws/coordinator.py
@@ -248,7 +248,7 @@ class WundergroundPWSUpdateCoordinator(DataUpdateCoordinator):
                 return None
 
             return self.data[FIELD_DAYPART][0][field][period]
-        except KeyError, TypeError, IndexError:
+        except (KeyError, TypeError, IndexError):
             return None
 
     @classmethod


### PR DESCRIPTION
Version 2.2.0 introduces an error when Home Assistant is running using Python 3:

```
Unexpected exception importing component custom_components.wundergroundpws
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.13/site-packages/homeassistant/loader.py", line 1078, in _get_component
    ComponentProtocol, importlib.import_module(self.pkg_path)
                       ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/srv/homeassistant/lib/python3.13/site-packages/homeassistant/util/loop.py", line 201, in protected_loop_func
    return func(*args, **kwargs)
  File "/root/.pyenv/versions/3.13.4/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/root/.homeassistant/custom_components/wundergroundpws/__init__.py", line 26, in <module>
    from .coordinator import (
    ...<2 lines>...
    )
  File "/root/.homeassistant/custom_components/wundergroundpws/coordinator.py", line 251
    except KeyError, TypeError, IndexError:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```

This PR fixes the syntax error