### PR TITLE
Set unit based on sensor description, independent of response data

### DIFF
--- a/custom_components/wundergroundpws/sensor.py
+++ b/custom_components/wundergroundpws/sensor.py
@@ -144,14 +144,15 @@ class WundergroundPWSSensor(CoordinatorEntity, SensorEntity):
             description.feature,
             forecast_day,
         )
-        # Only set unit of measurement if the sensor has a unit (avoid setting empty string for text sensors)
-        if self._sensor_data is not None:
-            unit = self.entity_description.unit_fn(
-                self.coordinator.hass.config.units is METRIC_SYSTEM
-            )
-            if unit is not None:
-                self._attr_native_unit_of_measurement = unit
-        # Note: For text sensors (like narrative/summary), we don't set native_unit_of_measurement at all
+        # Set unit based on sensor description, not data availability. The unit is a
+        # static property of the sensor type. Text sensors (narrative, summary, etc.)
+        # already return None from unit_fn, so the check below is sufficient to avoid
+        # setting a unit on those.
+        unit = self.entity_description.unit_fn(
+            self.coordinator.hass.config.units is METRIC_SYSTEM
+        )
+        if unit is not None:
+            self._attr_native_unit_of_measurement = unit
 
     @property
     def device_info(self) -> DeviceInfo:


### PR DESCRIPTION
This PR removes the `if self._sensor_data is not None:` check for setting unit of measurement, as we don't always have data available, and the unit should be tied to the sensor type, not specific response data.

The original issue that #293 tried to resolve was the `else ""` bit from:
```
self._attr_native_unit_of_measurement = self.entity_description.unit_fn(
    self.coordinator.hass.config.units is METRIC_SYSTEM) if self._sensor_data is not None else ""
```
 which was incorrectly setting the unit to an empty string for text sensors. This update should retain that fix but also handle scenarios where response data is not currently available.  I put a moderately verbose comment in the file, as I felt it might provide a bit more reasoning behind the somewhat back-and-forth changes. If you think it's unnecessary (with this PR serving as enough documentation), let me know and I will remove it.